### PR TITLE
Syntax error fix

### DIFF
--- a/coherence.py
+++ b/coherence.py
@@ -13,7 +13,7 @@ client = discord.Client()
 @client.event
 async def on_ready():
     print('Connected to Discord API')
-    prunt('------')
+    print('------')
     print('Logged in as')
     print(client.user.name)
     print(client.user.id)


### PR DESCRIPTION
# Description

Corrected a syntax misspelling in the `on_ready` __print__ functions.

Fixes # N/A

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Ran updated `coherence.py` in the testing Heroku environment. Tests passed.

- [x] After initial tests passed, deployed to official production Heroku environment.

**Test Configuration**:
* Python version: 3.7.3
* Discord.py version: 1.2.3

# Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
